### PR TITLE
Make forEach have the same interface as Array.prototype.forEach

### DIFF
--- a/lib/simple_lru.js
+++ b/lib/simple_lru.js
@@ -136,11 +136,10 @@ Cache.prototype.detach = function(element){
     this.size--
 }
 
-Cache.prototype.forEach = function(callback){
-    var self = this
+Cache.prototype.forEach = function(callback, thisArg){
     Object.keys(this.cache).forEach(function(key){
-        var val = self.cache[key]
-        callback(val.value,key)
-    })
+        var val = this.cache[key]
+        callback.call(thisArg, val.value, key, this)
+    }, this)
 }
 module.exports=Cache

--- a/test/simple_lru_tests.js
+++ b/test/simple_lru_tests.js
@@ -58,5 +58,41 @@ describe("BigCache Config",function(){
 
         for(var i = 0; i < 100; i++)
             cache.get(i).should.equal("value_"+i+"_modif")
-    }) 
+    })
+    it("Should have forEach with the same interface as Array#forEach", function() {
+        var cache = new SimpleCache({maxSize:10})
+        for(var i = 1; i <= 10; i++)
+            cache.set(i,"value_"+i)
+
+        var testContext1 = { test:1 }
+        var testContext2 = { other: 2 }
+
+        cache.forEach(function(value,key,passedCache){
+            should.exist(this)
+            should.exist(this.test)
+            should.exist(value)
+            should.exist(key)
+            should.exist(passedCache)
+            should(key).be.a.String();
+            should(passedCache).be.instanceof(SimpleCache);
+            this.should.equal(testContext1)
+            this.test.should.equal(1)
+            value.should.equal("value_" + key)
+            should(+key).be.greaterThanOrEqual(1)
+            should(+key).be.lessThanOrEqual(10)
+            passedCache.should.equal(cache)
+        }, testContext1);
+
+        cache.forEach(function(value,key,passedCache){
+            should.exist(this)
+            should.exist(this.other)
+            this.other.should.be.equal(2)
+            this.should.equal(testContext2)
+        }, testContext2);
+
+        var returnValue = cache.forEach(function(value, key) {
+            return 42;
+        });
+        should(returnValue).be.undefined();
+    })
 })


### PR DESCRIPTION
I have extended forEach to have the same behavior as the "real" `Array.prototype.forEach`.
- The real one passes the collection as an argument as the third parameter to the callback, useful for avoiding unnecessary closure to get the collection.
- The real one accepts a second parameter, used as the 'this' value in the callback. Also useful for avoiding unnecessary closure, and avoids having to setup `var self = this`.

This is almost a completely non-breaking change. The only tiny difference is, the callback is called with one additional argument. Callers should be expecting that argument in a forEach callback, that looks and acts just like Array#forEach, anyway.

The test is pretty exhaustive as well.
