### PR TITLE
fix get item without hit will return undefined

### DIFF
--- a/lib/simple_lru.js
+++ b/lib/simple_lru.js
@@ -43,10 +43,8 @@ Cache.prototype.get = function(key,hit){
      * it to the head of linked list  
      */
     hit = hit != undefined && hit != null ? hit : true;
-    if(cacheVal && hit)
-        this.hit(cacheVal)
-    else
-        return undefined
+    if(!cacheVal) return undefined
+    if(hit) this.hit(cacheVal)
     return cacheVal.value
 }
 


### PR DESCRIPTION
As title,
we can not get item without move it to the head of linked list.